### PR TITLE
Enhancement add q command line parser

### DIFF
--- a/src/webots/gui/WbGuiApplication.cpp
+++ b/src/webots/gui/WbGuiApplication.cpp
@@ -205,7 +205,7 @@ void WbGuiApplication::parseArguments() {
 
   // QStringList args = arguments(); ->Line should be removed, now fetching the arguments is done with the parser
   bool logPerformanceMode = false;
-  bool batch = false, stream = false;
+  bool batch = false, mstream = false;
 
   const int size = args.size();
   for (int i = 1; i < size; ++i) {

--- a/src/webots/gui/WbGuiApplication.cpp
+++ b/src/webots/gui/WbGuiApplication.cpp
@@ -41,6 +41,7 @@
 #include <QtCore/QStringList>
 #include <QtCore/QTimer>
 #include <QtCore/QUrl>
+#include <QtCore/QCommandLineParser>
 #include <QtGui/QFontDatabase>
 #include <QtGui/QScreen>
 
@@ -185,9 +186,26 @@ void WbGuiApplication::parseStreamArguments(const QString &streamArguments) {
 
 void WbGuiApplication::parseArguments() {
   // faster when copied according to Qt's doc
-  QStringList args = arguments();
-  bool logPerformanceMode = false, batch = false;
-  mStream = false;
+
+  // Integration of QCommandLineParser
+  QCommandLineParser parser;
+  parser.setOptionsAfterPositionalArgumentsMode(QCommandLineParser::ParseAsOptions);
+  // parser.addPositionalArgument("subcommands", "minimize"); -> add all the subcommands later
+  parser.parse(QCoreApplication::arguments());
+  const QStringList args = parser.positionalArguments();
+
+  /* example of handling a subcommand
+  if (!parserArgs.isEmpty()) {
+    const QString subCommand = parserArgs.first();
+    if (subCommand == "minimize") {
+      parserArgs.pop_front();
+      subProgram(parserArgs);
+    }
+  } */
+
+  // QStringList args = arguments(); ->Line should be removed, now fetching the arguments is done with the parser
+  bool logPerformanceMode = false;
+  bool batch = false, stream = false;
 
   const int size = args.size();
   for (int i = 1; i < size; ++i) {


### PR DESCRIPTION
…seArguments function. However, I did not implement the handling of the subcommands or any validity checks for them, as was said in the issue discussion.

**Description**
 Adding QCommandLineParser to parse command-line arguments.

**Related Issues**
This pull-request fixes issue #

**Tasks**
Add the list of tasks of this PR.
  - [ ] Task 1
  - [ ] Task 2

**Documentation**
If this pull-request changes the doc, add the link to the related page, including the `?version=BRANCH_NAME`, such as:
https://cyberbotics.com/doc/guide/getting-started-with-webots?version=develop

**Screenshots**
If this pull-request includes any new robots/simulations/etc. add one or more screenshots of the result.

**Additional context**
Add any other context about the pull-request here.
